### PR TITLE
statestorage: Remove go-sqlite3 dependency

### DIFF
--- a/statestorage/statestorage_mgr.go
+++ b/statestorage/statestorage_mgr.go
@@ -14,10 +14,8 @@ import (
     "strings"
     "encoding/json"
     "time"
-
     "database/sql"
     "fmt"
-    _ "github.com/mattn/go-sqlite3"
 )
 type PathList struct {
 	LeafPaths []string


### PR DESCRIPTION
It seems to me that....

statestorage does not build because the package
"github.com/mattn/go-sqlite3" is not found with the "_" in front
of it.
However, if package is installed first, go says it is imported and not
used by the file statestorage_mgr.go
It seems like it can be removed since database/sql is used instead?

When I switched to this instead, then it builds OK in a new fresh container.
